### PR TITLE
lex ext. mod.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,6 @@ Nums are assigned on the execution line (last indent). Bools are also assigned o
 Only booleans can be read on the run bit scan (mid-indent)
 
 ```
-external_module_default_implementation:=
-    1:
-        exec:=
-    0:
-        default implementation for a boolean type is specified with a := without a value after it in the last indentation position
-
 print:=
     1:
         exec:=
@@ -51,6 +45,70 @@ last_module:
     0:
         ^^^ prints out a 1
 ```
+
+## External modules
+
+External modules are declared with the default implementation `:=` operator:
+
+```
+ext_mod:=
+```
+
+In order to invoke their special bool functions, you create them with by flagging them with a non-bool primitive type cast: `{num|str}<ext_mod>.special_bool`.
+
+External modules do not have normal booleans and should fail to compile a falsy assignment:
+
+```
+external_mod:=
+    1:
+        special_bool:=
+normal_mod:
+    1:
+        em = 1<external_mod>
+        !em.special_bool
+    0:
+        ^^^ falsy should fail compilation
+        vvv truthy will compile (as it invokes a special_bool C lib function)
+    1:
+        em.special_bool
+    em.special_bool:
+        :
+    0:
+        ^^^ enters code block conditioned on external special_bool status
+```
+
+Dictionary **k**ey/**v**alue example:
+
+```
+int_str_dict:=
+    0:
+        vars
+    1:
+        temp_k := 0
+        temp_v := ``
+        lookup_k := 0
+        lookup_v := ``
+    0:
+        special bool functions (can be falsy in default implementation)
+    1:
+        !add_temp:=
+        !lookup:=
+
+program_module:
+    0:
+        0 initial capacity
+    1:
+        d = 0<int_str_dict>
+        d.temp_k = 1
+        d.temp_v = `one`
+        d.add_temp
+        d.lookup_key = 1
+        d.lookup
+    d.lookup:
+        val = d.lookup_v
+```
+
+
 
 # Key Terms
 

--- a/docs/ned_dfa.svg
+++ b/docs/ned_dfa.svg
@@ -94,7 +94,7 @@
     <text x="616" y="711" fill="black" id="text55">"{varchain}:="</text>
     <polyline points="564 395 564 620 554 610 564 620 574 610" stroke="green" fill="transparent" stroke-width="1" id="polyline26"/>
     <text x="456" y="622" fill="black" id="text56">{varchain}</text>
-    <polyline points="574 331 574 285 564 295 574 285 584 295" stroke="black" fill="transparent" stroke-width="1" id="polyline27"/>
+    <polyline points="574 331 574 285 564 295 574 285 584 295" stroke="green" fill="transparent" stroke-width="1" id="polyline27"/>
     <text x="21" y="142" fill="black" id="text58">number - 0-9(.0-9)</text>
     <text x="21" y="163" fill="black" id="text59">string `..`</text>
     <circle cx="575" cy="252" r="31" fill="transparent" stroke="black" stroke-width="1" id="circle12"/>
@@ -102,13 +102,13 @@
     <text x="509" y="228" fill="black" id="text60">\n</text>
     <circle cx="446" cy="217" r="30" fill="transparent" stroke="black" stroke-width="1" id="circle13"/>
     <text x="426" y="226" fill="black" id="text61">*SoL</text>
-    <polyline points="569 222 569 163 559 173 569 163 579 173" stroke="black" fill="transparent" stroke-width="1" id="polyline29"/>
+    <polyline points="569 222 569 163 559 173 569 163 579 173" stroke="green" fill="transparent" stroke-width="1" id="polyline29"/>
     <text x="531" y="212" fill="black" id="text62">.{exec}</text>
     <text x="15" y="629" fill="black" id="text63">exec -</text>
     <text x="50" y="677" fill="black" id="text64">api interface (or any var naming)</text>
     <text x="50" y="653" fill="black" id="text65">"exec" by convention for a single</text>
     <circle cx="567" cy="142" r="17" fill="transparent" stroke="black" stroke-width="1" id="circle14"/>
-    <polyline points="543 155 476 191 485.7834027785064 193.94451928285145 476 191 478.94451928285145 181.2165972214936" stroke="black" fill="transparent" stroke-width="1" id="polyline30"/>
+    <polyline points="543 155 476 191 485.7834027785064 193.94451928285145 476 191 478.94451928285145 181.2165972214936" stroke="green" fill="transparent" stroke-width="1" id="polyline30"/>
     <text x="505" y="187" fill="black" id="text66">\n</text>
     <text x="628" y="651" fill="black" id="text67">* \n -&gt; *SoL</text>
     <polyline points="603 343 673 199 662.1913677732914 202.73756441484312 673 199 676.7375644148432 209.8086322267086" stroke="green" fill="transparent" stroke-width="1" id="polyline31"/>

--- a/docs/ned_dfa.svg
+++ b/docs/ned_dfa.svg
@@ -98,7 +98,7 @@
     <text x="21" y="142" fill="black" id="text58">number - 0-9(.0-9)</text>
     <text x="21" y="163" fill="black" id="text59">string `..`</text>
     <circle cx="575" cy="252" r="31" fill="transparent" stroke="black" stroke-width="1" id="circle12"/>
-    <polyline points="544 245 479 220 483.3514263457634 229.79070927796758 479 220 488.79070927796755 215.64857365423663" stroke="black" fill="transparent" stroke-width="1" id="polyline28"/>
+    <polyline points="544 245 479 220 483.3514263457634 229.79070927796758 479 220 488.79070927796755 215.64857365423663" stroke="green" fill="transparent" stroke-width="1" id="polyline28"/>
     <text x="509" y="228" fill="black" id="text60">\n</text>
     <circle cx="446" cy="217" r="30" fill="transparent" stroke="black" stroke-width="1" id="circle13"/>
     <text x="426" y="226" fill="black" id="text61">*SoL</text>
@@ -116,16 +116,16 @@
     <circle cx="682" cy="184" r="17" fill="transparent" stroke="black" stroke-width="1" id="circle15"/>
     <circle cx="709" cy="102" r="17" fill="transparent" stroke="black" stroke-width="1" id="circle16"/>
     <circle cx="627" cy="123" r="17" fill="transparent" stroke="black" stroke-width="1" id="circle19"/>
-    <polyline points="668 170 634 142 634.9982683969693 152.31544010201546 634 142 644.3154401020155 141.0017316030307" stroke="black" fill="transparent" stroke-width="1" id="polyline32"/>
+    <polyline points="668 170 634 142 634.9982683969693 152.31544010201546 634 142 644.3154401020155 141.0017316030307" stroke="green" fill="transparent" stroke-width="1" id="polyline32"/>
     <polyline points="691 167 714 136 704.0390175171982 137.47570110856321 714 136 715.4757011085633 145.96098248280188" stroke="green" fill="transparent" stroke-width="1" id="polyline33"/>
     <text x="13" y="706" fill="black" id="text69">{externModuleCast} -</text>
     <text x="59" y="728" fill="black" id="text70">"[{number}|{string}]&lt;Extmodule&gt;"</text>
     <text x="386" y="312" fill="black" id="text71">{externModuleCast}</text>
     <text x="591" y="153" fill="black" id="text72">{extMdCst}</text>
-    <polyline points="613 96 446 180 455.56499532155937 183.16292673979848 446 180 449.1629267397985 170.4350046784406" stroke="black" fill="transparent" stroke-width="1" id="polyline34"/>
+    <polyline points="613 96 446 180 455.56499532155937 183.16292673979848 446 180 449.1629267397985 170.4350046784406" stroke="green" fill="transparent" stroke-width="1" id="polyline34"/>
     <text x="537" y="118" fill="black" id="text73">* \n</text>
     <text x="642" y="131" fill="black" id="text74">{num}|{str}</text>
-    <polyline points="732 312 699 381 709.9280138910649 377.14305392080064 699 381 695.1430539208006 370.07198610893516" stroke="black" fill="transparent" stroke-width="1" id="polyline35"/>
+    <polyline points="732 312 699 381 709.9280138910649 377.14305392080064 699 381 695.1430539208006 370.07198610893516" stroke="green" fill="transparent" stroke-width="1" id="polyline35"/>
     <circle cx="700" cy="402" r="17" fill="transparent" stroke="black" stroke-width="1" id="circle17"/>
     <text x="649" y="298" fill="black" id="text75">{varchain}</text>
     <polyline points="616 372 677 437 677.324573604479 426.7759314589093 677 437 666.7759314589093 436.675426395521" stroke="green" fill="transparent" stroke-width="1" id="polyline36"/>
@@ -133,11 +133,7 @@
     <text x="15" y="583" fill="black" id="text77">var -</text>
     <text x="55" y="603" fill="black" id="text78">"{leadId}{id}"</text>
     <circle cx="691" cy="453" r="17" fill="transparent" stroke="black" stroke-width="1" id="circle18"/>
-    <line x1="696" y1="193" x2="733" y2="312" stroke="black" stroke-width="1" id="line4"/>
-    <circle cx="629" cy="248" r="17" fill="transparent" stroke="black" stroke-width="1" id="circle20"/>
-    <polyline points="617 132 645 233 650.5305851814232 223.22677413145746 645 233 635.2267741314574 227.46941481857675" stroke="black" fill="transparent" stroke-width="1" id="polyline37"/>
-    <polyline points="647 252 720 274 715.059938925957 264.79792545031205 720 274 710.797925450312 278.940061074043" stroke="black" fill="transparent" stroke-width="1" id="polyline38"/>
-    <text x="619" y="199" fill="black" id="text79">.</text>
+    <line x1="696" y1="193" x2="733" y2="312" stroke="green" stroke-width="1" id="line4"/>
     <text x="17" y="475" fill="green" id="text80">Green edges have</text>
     <text x="17" y="495" fill="green" id="text81">at least 1 lex test</text>
     <text x="17" y="515" fill="red" id="text82">todo: really needs to test</text>

--- a/main.c
+++ b/main.c
@@ -27,7 +27,7 @@ const char *map(int i) {
         case 10:
             return "TOKEN_NEGATE";
         case 11:
-            return "TOKEN_TYPE_MONAD";
+            return "TOKEN_EXTERNAL_MODULE";
         case 12:
             return "TOKEN_DOT";
         case 13:

--- a/test/assign_ext_mod.ned
+++ b/test/assign_ext_mod.ned
@@ -1,0 +1,23 @@
+ext_mod:=
+    1:
+        a := ``
+        b := ``
+        res := ``
+        !str_cat:=
+
+m1:
+    1:
+        str = `test`
+
+m2:
+    1:
+        em = `test`<ext_mod>
+    0:
+        Note: this (deep reach on rhs) is not supported: 
+        em.str_cat = m1.str<ext_mod>.res
+        Neither is assigning a module to another module's variable:
+        m1.foo = ext_mod
+        Nor can booleans be assigned with equals
+        m1.foo = ext_mod.str_cat
+        Must do 2 lines sep indents:
+        \t ext_mod.str_cat \n \t \t m1.foo 

--- a/test/assign_mod.ned
+++ b/test/assign_mod.ned
@@ -1,0 +1,11 @@
+m1:
+    1:
+        str = `test1`
+
+m2:
+    1:
+        str = `test2`
+
+m3:
+    1:
+        m2.str = m1.str

--- a/test/assign_str.ned
+++ b/test/assign_str.ned
@@ -1,0 +1,7 @@
+m1:
+    1:
+        str = `test1`
+
+m2:
+    1:
+        m1.str = `test2`

--- a/test/ext_init_only.ned
+++ b/test/ext_init_only.ned
@@ -1,0 +1,10 @@
+print:=
+    1:
+        exec:=
+
+mod:
+    1:
+        1<print>
+    0:
+        assume int initializer is specifying num of times to print
+        but print was never invoced with .exec

--- a/test/ext_int_exec.ned
+++ b/test/ext_int_exec.ned
@@ -1,4 +1,4 @@
-ext:=
+ext_key_value:=
     1:
         exec:=
 

--- a/test/ext_int_exec.ned
+++ b/test/ext_int_exec.ned
@@ -1,0 +1,7 @@
+ext:=
+    1:
+        exec:=
+
+m:
+    1:
+        11<ext_key_value>.exec

--- a/test/ext_str_exec.ned
+++ b/test/ext_str_exec.ned
@@ -1,4 +1,4 @@
-ext:=
+ext_key_value:=
     1:
         exec:=
 

--- a/test/ext_str_exec.ned
+++ b/test/ext_str_exec.ned
@@ -1,0 +1,7 @@
+ext:=
+    1:
+        exec:=
+
+m:
+    1:
+        `my_string`<ext_key_value>.exec

--- a/test/run
+++ b/test/run
@@ -98,6 +98,34 @@ err2=$?
 
 err=$((err+err1+err2))
 
+# LONG RUNLINES
+
+gcc -std=c2x ../main.c ../tokenizer.c -o ./generator
+# ./generator ./ext_str_exec.ned 2>&1
+res=$(./generator ./ext_str_exec.ned 2>&1)
+echo "$res" | grep -q "TOKEN_EXTERNAL_MODULE(ext_key_value)"
+err1=$?
+echo "$res" | grep -q "TOKEN_INVALID"
+if [[ $? -eq 0 ]]; then
+    err2=1 # invert grep q (should not match invalid)
+else
+    err2=0
+fi
+
+gcc -std=c2x ../main.c ../tokenizer.c -o ./generator
+# ./generator ./ext_int_exec.ned 2>&1
+res=$(./generator ./ext_int_exec.ned 2>&1)
+echo "$res" | grep -q "TOKEN_EXTERNAL_MODULE(ext_key_value)"
+err3=$?
+echo "$res" | grep -q "TOKEN_INVALID"
+if [[ $? -eq 0 ]]; then
+    err4=1 # invert grep q (should not match invalid)
+else
+    err4=0
+fi
+
+err=$((err+err1+err2+err3+err4))
+
 
 # FINAL SUM 0 CHECK
 

--- a/test/run
+++ b/test/run
@@ -63,6 +63,28 @@ err2=$?
 
 err=$((err+err1+err2))
 
+# EXTERNAL INITIALIZATION ONLY
+
+gcc -std=c2x ../main.c ../tokenizer.c -o ./generator
+res=$(./generator ./ext_init_only.ned 2>&1)
+
+init_line=$(cat <<EOF
+TOKEN_INDENT(\s\s\s\s)
+TOKEN_INDENT(\s\s\s\s)
+TOKEN_NUMBER(1)
+TOKEN_EXTERNAL_MODULE(print)
+EOF
+)
+
+init_snippet=$(echo "$res" | tail -23 | head -4)
+if [[ "$init_snippet" == "$init_line" ]]; then
+    err1=0
+else
+    err1=1
+fi
+
+err=$((err+err1))
+
 # NON-EXTERNAL BOOLEAN TEST VARIATIONS
 # \t \t {varchain}
 # \t \t !{varchain}
@@ -94,6 +116,72 @@ res=$(./generator ./decr_op.ned 2>&1)
 echo "$res" | grep -q "TOKEN_DECREMENT(--)"
 err1=$?
 echo "$res" | grep -q "TOKEN_NUMBER(2)"
+err2=$?
+
+err=$((err+err1+err2))
+
+# STR ASSIGNMENT TEST
+
+gcc -std=c2x ../main.c ../tokenizer.c -o ./generator
+# ./generator ./assign_str.ned 2>&1
+res=$(./generator ./assign_str.ned 2>&1)
+echo "$res" | grep -q "TOKEN_VARIABLE_IDENTIFIER(str)"
+err1=$?
+echo "$res" | grep -q "TOKEN_EQUALS(=)"
+err2=$?
+echo "$res" | grep -q "TOKEN_STRING(test1)"
+err3=$?
+echo "$res" | grep -q "TOKEN_STRING(test2)"
+err4=$?
+echo "$res" | grep -q "TOKEN_INVALID"
+if [[ $? -eq 0 ]]; then
+    err5=1 # invert grep q (should not match invalid)
+else
+    err5=0
+fi
+
+err=$((err+err1+err2+err3+err4+err5))
+
+# MOD VAR ASSIGNMENT TEST
+
+gcc -std=c2x ../main.c ../tokenizer.c -o ./generator
+# ./generator ./assign_mod.ned 2>&1
+res=$(./generator ./assign_mod.ned 2>&1)
+
+# \t \t m2.str = m1.str
+assignment=$(cat<<EOF
+TOKEN_INDENT(\s\s\s\s)
+TOKEN_INDENT(\s\s\s\s)
+TOKEN_MODULE_IDENTIFIER(m2)
+TOKEN_DOT(.)
+TOKEN_VARIABLE_IDENTIFIER(str)
+TOKEN_SPACE( )
+TOKEN_EQUALS(=)
+TOKEN_SPACE( )
+TOKEN_MODULE_IDENTIFIER(m1)
+TOKEN_DOT(.)
+TOKEN_VARIABLE_IDENTIFIER(str)
+EOF
+)
+
+output_snippet=$(echo "$res" | tail -15 | head -11)
+
+if [[ "$output_snippet" == "$assignment" ]]; then
+    err1=0
+else
+    err1=1
+fi
+err=$((err+err1))
+
+# ASSIGN EXTERN MOD
+
+gcc -std=c2x ../main.c ../tokenizer.c -o ./generator
+# ./generator ./assign_ext_mod.ned 2>&1
+res=$(./generator ./assign_ext_mod.ned 2>&1)
+
+echo "$res" | grep -q "TOKEN_EXTERNAL_MODULE(ext_mod)"
+err1=$?
+echo "$res" | grep -q "TOKEN_TEXT"  # comment
 err2=$?
 
 err=$((err+err1+err2))

--- a/token.h
+++ b/token.h
@@ -90,7 +90,7 @@ typedef enum {
                              // |------------|-------------|-------------------|
                              //                !bool_var    !bool_var
 
-    TOKEN_TYPE_MONAD,        //  col1         col2          col3*
+    TOKEN_EXTERNAL_MODULE,   //  col1         col2          col3*
                              // |------------|-------------|-------------------|
                              //  shell:=       1:           exec:=
                              //  shell:=       1:           input:="my test"


### PR DESCRIPTION
Todos:

- [x] lex assignment lines for external modules (make top-right of graph green w/ unit tests)
- [x] clean up this example and add it to the docs to explain special external module boolean functionality
- [x] todo: this syntax, `!my_ext_mod.exec`,  should not be allowed because in ned not-bool will assign it to false and so then this syntax makes no sense to execute external code and tell it the return result will be false. Pretty much it should be only assignable via external module (c code) and even after reading the value it should never become available to re-assign by ned code

external modules are like flags in the code (like symbolically have <> notation to flag special side effects on the subsequent boolean-like assignment and then boolean value read of the result status of that side effect), ascii-drawn flag as a mnemonic:

```
:<flag>
|
|
```

Boolean-like assignment:
```
ext_key_value:=
    1:
        exec:=

m:
    1:
        11<ext_key_value>.exec
```

Boolean-like read result after same boolean assignment, in this example is `lookup` (still need to code for this):
```

ext_int_str_dictionary:=
    0:
        note: default implementation number/string variable values below
    1:
        temp_key := 0
        temp_val := ``
        lookup_key := 0
        lookup_val := ``
    0:
        note: default implementation special external-module (side-effect) booleans below
    1:
        !add_temp:=
        !lookup:=

m:
    1:
        d = 0<ext_int_str_dictionary>
    0:
        note: 0-init. capacity dictionary initialized. at end of run module val will be set to `one`
    1:
        d.temp_key = 1
        d.temp_val = `one`
        d.add_temp
        d.lookup_key = 1
        d.lookup
    d.lookup:
        val = d.lookup_val
```